### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,23 +5,23 @@ declare class IPC extends Duplex {
   constructor(port: IPCPort)
 }
 
-declare interface IPCPort {
+interface IPCPort extends Transferable<[incoming: number, outgoing: number]> {
   readonly incoming: number
   readonly outgoing: number
   readonly detached: boolean
 
   connect(): IPC
-
-  [symbols.detach](): [incoming: number, outgoing: number]
 }
 
-declare class IPCPort implements Transferable {
+declare class IPCPort {
   constructor(incoming: number, outgoing: number)
 
   static [symbols.attach](input: [incoming: number, outgoing: number]): IPCPort
 }
 
 declare namespace IPC {
+  export { IPCPort }
+
   export function open(): [IPCPort, IPCPort]
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+import { Duplex } from 'bare-stream'
+
+declare class IPC extends Duplex {
+  constructor(port: IPCPort)
+}
+
+declare interface IPCPort {
+  incoming: string | number
+  outgoing: string | number
+  detached: boolean
+
+  connect(): IPC
+}
+
+declare class IPCPort {
+  constructor(incoming: string | number, outgoing: string | number)
+}
+
+declare namespace IPC {
+  export function open(): [IPCPort, IPCPort]
+}
+
+export = IPC

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,24 @@
 import { Duplex } from 'bare-stream'
+import { Transferable, symbols } from 'bare-structured-clone'
 
 declare class IPC extends Duplex {
   constructor(port: IPCPort)
 }
 
 declare interface IPCPort {
-  incoming: string | number
-  outgoing: string | number
-  detached: boolean
+  readonly incoming: number
+  readonly outgoing: number
+  readonly detached: boolean
 
   connect(): IPC
+
+  [symbols.detach](): [incoming: number, outgoing: number]
 }
 
-declare class IPCPort {
-  constructor(incoming: string | number, outgoing: string | number)
+declare class IPCPort implements Transferable {
+  constructor(incoming: number, outgoing: number)
+
+  static [symbols.attach](input: [incoming: number, outgoing: number]): IPCPort
 }
 
 declare namespace IPC {

--- a/index.js
+++ b/index.js
@@ -79,6 +79,8 @@ class IPCPort {
   }
 }
 
+exports.IPCPort = IPCPort
+
 exports.open = function open() {
   const a = Pipe.pipe()
   const b = Pipe.pipe()

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const Pipe = require('bare-pipe')
 const { Duplex } = require('bare-stream')
+const { symbols } = require('bare-structured-clone')
 const errors = require('./lib/errors')
 
 module.exports = exports = class IPC extends Duplex {
@@ -61,7 +62,7 @@ class IPCPort {
     return ipc
   }
 
-  [Symbol.for('bare.detach')]() {
+  [symbols.detach]() {
     if (this.detached) {
       throw errors.ALREADY_CONNECTED(
         'Port has already started receiving messages'
@@ -73,7 +74,7 @@ class IPCPort {
     return [this.incoming, this.outgoing]
   }
 
-  static [Symbol.for('bare.attach')]([incoming, outgoing]) {
+  static [symbols.attach]([incoming, outgoing]) {
     return new this(incoming, outgoing)
   }
 }

--- a/index.js
+++ b/index.js
@@ -78,9 +78,9 @@ class IPCPort {
   }
 }
 
-exports.open = function open(opts) {
-  const a = Pipe.pipe(opts)
-  const b = Pipe.pipe(opts)
+exports.open = function open() {
+  const a = Pipe.pipe()
+  const b = Pipe.pipe()
 
-  return [new IPCPort(a[0], b[1], opts), new IPCPort(b[0], a[1], opts)]
+  return [new IPCPort(a[0], b[1]), new IPCPort(b[0], a[1])]
 }

--- a/lib/errors.d.ts
+++ b/lib/errors.d.ts
@@ -1,0 +1,5 @@
+declare class IPCError extends Error {
+  static ALREADY_CONNECTED(msg: string): IPCError
+}
+
+export = IPCError

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "homepage": "https://github.com/holepunchto/bare-ipc#readme",
   "dependencies": {
     "bare-pipe": "^4.0.0",
-    "bare-stream": "^2.1.3"
+    "bare-stream": "^2.1.3",
+    "bare-structured-clone": "^1.4.0"
   },
   "devDependencies": {
     "brittle": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,19 @@
   "version": "1.0.1",
   "description": "Lightweight pipe-based IPC for Bare",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
     "./package": "./package.json",
-    "./errors": "./lib/errors.js"
+    "./errors": {
+      "types": "./lib/errors.d.ts",
+      "default": "./lib/errors.js"
+    }
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "lib"
   ],
   "scripts": {


### PR DESCRIPTION
Removed `opts` argument from `open` function because it doesn't seem to be used.

And I couldn't find the correct syntax to properly type symbols like `bare.detach` on a declaration file.